### PR TITLE
Adding accuracy metric used in MTGenEval paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example usage for English-Russian contextual dev dataset is as follows
 python3 accuracy_metric.py \
         --target_lang ru \
         --dataset contextual \
-        --data_split dev \
+        --data_split test \
         --hyp PATH_FOR_YOUR_SYSTEM_TRANSLATIONS
 ```
 Example usage for English-Russian counterfactual dev dataset is as follows
@@ -42,12 +42,10 @@ Example usage for English-Russian counterfactual dev dataset is as follows
 python3 accuracy_metric.py \
         --target_lang ru \
         --dataset counterfactual \
-        --data_split dev \
+        --data_split test \
         --hyp_masculine PATH_FOR_YOUR_SYSTEM_TRANSLATIONS_FOR_MASCULINE_SEGMENTS \
         --hyp_feminine PATH_FOR_YOUR_SYSTEM_TRANSLATIONS_FOR_FEMININE_SEGMENTS
 ```
-
-Note that --hyp and 
 
 ## Security
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/README.md
+++ b/README.md
@@ -28,21 +28,26 @@ The data is originally sourced from Wikipedia.
 We include sentence-level development and test segments in `data/sentences/` and inter-sentence test segments in `data/context/`. 
 
 ## Compute accuracy
-To compute accuracy, call `accuracy_metric` function in `accuracy_metric.py`. Example usage for English-Russian contextual dataset is as follows
+To compute accuracy, use `accuracy_metric.py` script. 
+Example usage for English-Russian contextual dev dataset is as follows
 ```
-hypothesis_path = PATH_FOR_YOUR_SYSTEM_TRANSLATIONS
-references_path = 'data/context/geneval-context-wikiprofessions-original-test.en_ru.ru'
-flipped_references_path = 'data/context/geneval-context-wikiprofessions-flipped-test.en_ru.ru'
-accuracy, metric_decisions = accuracy_metric(hypothesis_path, references_path, flipped_references_path)
+python3 accuracy_metric.py \
+        --target_lang ru \
+        --dataset contextual \
+        --data_split dev \
+        --hyp PATH_FOR_YOUR_SYSTEM_TRANSLATIONS
 ```
-For counterfactual dataset (the data in `data/sentences/`), metric decision can be obtained similarly but the accuracy computation is a little different as mentioned in Sec 3.1 of the paper. We consider a segment `Correct` only if both the original and the counterfactual segments are `Correct`. More specifically, 
+Example usage for English-Russian counterfactual dev dataset is as follows
 ```
-_, metric_decisions_masculine = accuracy_metric(hypothesis_masculine_path, masculine_references_path, female_references_path)
-_, metric_decisions_feminine = accuracy_metric(hypothesis_feminine_path, feminine_references_path, masculine_references_path)
-accuracy, combined_decision = logicaloperation_AND(metric_decisions_masculine, metric_decisions_feminine)
+python3 accuracy_metric.py \
+        --target_lang ru \
+        --dataset counterfactual \
+        --data_split dev \
+        --hyp_masculine PATH_FOR_YOUR_SYSTEM_TRANSLATIONS_FOR_MASCULINE_SEGMENTS \
+        --hyp_feminine PATH_FOR_YOUR_SYSTEM_TRANSLATIONS_FOR_FEMININE_SEGMENTS
 ```
 
-
+Note that --hyp and 
 
 ## Security
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ The MT-GenEval benchmark was released in the EMNLP 2022 paper [MT-GenEval: A Cou
 The data is originally sourced from Wikipedia. 
 We include sentence-level development and test segments in `data/sentences/` and inter-sentence test segments in `data/context/`. 
 
+## Compute accuracy
+To compute accuracy, call `accuracy_metric` function in `accuracy_metric.py`. Example usage for English-Russian contextual dataset is as follows
+```
+hypothesis_path = PATH_FOR_YOUR_SYSTEM_TRANSLATIONS
+references_path = 'data/context/geneval-context-wikiprofessions-original-test.en_ru.ru'
+flipped_references_path = 'data/context/geneval-context-wikiprofessions-flipped-test.en_ru.ru'
+accuracy, metric_decisions = accuracy_metric(hypothesis_path, references_path, flipped_references_path)
+```
+For counterfactual dataset (the data in `data/sentences/`), metric decision can be obtained similarly but the accuracy computation is a little different as mentioned in Sec 3.1 of the paper. We consider a segment `Correct` only if both the original and the counterfactual segments are `Correct`. More specifically, 
+```
+_, metric_decisions_masculine = accuracy_metric(hypothesis_masculine_path, masculine_references_path, female_references_path)
+_, metric_decisions_feminine = accuracy_metric(hypothesis_feminine_path, feminine_references_path, masculine_references_path)
+accuracy, combined_decision = logicaloperation_AND(metric_decisions_masculine, metric_decisions_feminine)
+```
+
+
+
 ## Security
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We include sentence-level development and test segments in `data/sentences/` and
 
 ## Compute accuracy
 To compute accuracy, use `accuracy_metric.py` script. 
-Example usage for English-Russian contextual dev dataset is as follows
+Example usage for English-Russian contextual test dataset is as follows
 ```
 python3 accuracy_metric.py \
         --target_lang ru \
@@ -37,7 +37,7 @@ python3 accuracy_metric.py \
         --data_split test \
         --hyp PATH_FOR_YOUR_SYSTEM_TRANSLATIONS
 ```
-Example usage for English-Russian counterfactual dev dataset is as follows
+Example usage for English-Russian counterfactual test dataset is as follows
 ```
 python3 accuracy_metric.py \
         --target_lang ru \

--- a/accuracy_metric.py
+++ b/accuracy_metric.py
@@ -1,0 +1,118 @@
+"""
+Automatic accuracy metric for MT-GenEval paper.
+We use the correct (gender-matched) references and incorrect (counterfactual/swapped) references to evaluate accuracy.
+We first check the references for unique/gender-specific terms, then check for overlap with the incorrect gender
+and the hypothesis. If there is overlap, we mark the segment as incorrect.
+"""
+import string
+
+
+STRIP_PUNCT = str.maketrans(string.punctuation, ' '*len(string.punctuation))
+
+
+def accuracy_metric(hypothesis, cor_ref, inc_ref):
+    '''
+    INPUTS
+        hypothesis -- AMT hypothesis file to be evaluated
+        cor_ref -- Correctly gendered reference file path
+        inc_ref -- Incorrect (counterfactual) reference file path
+    We assume input files contain one sentence per line
+        
+    RETURNS decision (Corrct/Incorrect), one per each line in the input files
+    '''
+    # read in the files. 
+    # Note that each line of the input files will be lowercased and punctuation will be removed. 
+    trg_list = read_file_to_list(hypothesis)
+    cor_list = read_file_to_list(cor_ref)
+    inc_list = read_file_to_list(inc_ref)
+
+    assert len(trg_list) == len(cor_list), f'Output file and original reference file must have the same number of lines. Files are {hypothesis}, {cor_ref}'
+    assert len(trg_list) == len(inc_list), f'Output file and counterfactual reference file must have the same number of lines. Files are {hypothesis},  {inc_ref}'
+
+    # get the pre-specified label map
+    label_map = gender_label_map()
+
+    metric_annot_mapped = []    
+    for trg_line, cor_line, inc_line in zip(trg_list, cor_list, inc_list):
+        [decision, trg_correct, trg_incorrect] = gender_decision(trg_line, cor_line, inc_line)
+        metric_annot_mapped.append(decision) 
+    accuracy = metric_annot_mapped.count('Correct')/len(metric_annot_mapped)
+    return accuracy, metric_annot_mapped
+
+
+def gender_label_map():
+    ## it is a pre-specified label map used for model training
+    label_map = {'Correct':'Correct',
+                'Unspecified': 'Correct',
+                'Incorrect':'Incorrect',
+                'Mixed': 'Incorrect',
+                'Other': 'Incorrect'}
+    return label_map
+
+
+def _clean_line(line):
+    """
+    For an input line, lowercase it, strip extra spaces, and replace punctuation with spaces.
+
+    :param line: Line to clean.
+    :return: Cleaned version of the line
+    """
+    return line.lower().translate(STRIP_PUNCT).strip()
+
+
+def _get_words(line):
+    """
+    Helper function to get the set of words in a line.
+
+    :param line: Line from which to get the words.
+    :return: Set of words in the line.
+    """
+    return set(line.strip().split())
+
+
+def get_trg_correct_incorrect(cor_words, inc_words, trg_words):
+    cor_unique = cor_words - inc_words
+    inc_unique = inc_words - cor_words
+    # now check the words in the target sentence for overlap with incorrect unique words
+    trg_correct = trg_words & cor_unique 
+    trg_incorrect = trg_words & inc_unique
+    return trg_correct, trg_incorrect 
+
+
+def gender_decision(trg_line, cor_line, inc_line):
+    """
+    Check if gender of a sentence is correct based on corresponding correct and incorrect references.
+    Algorithm: We make decision based on whether hyp overlaps with original ref and counterfactual ref
+
+    :param trg_line: Sentence from translation output for which to check gender.
+    :param cor_line: Feminine reference.
+    :param inc_line: Masculine reference.
+    :return: a list of decision, overlap(hyp, original ref), overlap(hyp, counterfactual ref)
+    """
+    # start by getting unique words in each of the references
+    cor_words, inc_words = _get_words(cor_line), _get_words(inc_line)
+    trg_words = _get_words(trg_line)
+    trg_correct, trg_incorrect = get_trg_correct_incorrect(cor_words, inc_words, trg_words)
+
+    if (trg_incorrect):
+        decision = 'Incorrect'
+    else:
+        decision = 'Correct'
+
+    return [decision, trg_correct, trg_incorrect]
+
+
+def read_file_to_list(filename):
+    """
+    Read a file to a list of lines; each line will be lowercased and punctuation will be removed.
+
+    :param filename: File to read.
+    :return: List of lines of the file.
+    """
+    out_list = []
+    with open(filename, 'r') as infile:
+        for line in infile:
+            cleaned_line = _clean_line(line)
+            out_list.append(cleaned_line)
+    return out_list
+

--- a/accuracy_metric.py
+++ b/accuracy_metric.py
@@ -37,6 +37,11 @@ def accuracy_metric(hypothesis, cor_ref, inc_ref):
 
 
 def logicaloperation_AND(decision1, decision2):
+    """
+    Performs AND operation (per line) on the inputs: returns 'Correct' only if both inputs are 'Correct'. 
+    :param decision1 and decision2: lists with each line either 'Correct' or 'Incorrect'
+    :return: accuracy and list of decisions
+    """
     combined_decision = ['Incorrect' if 'Incorrect' in [d1,d2] else 'Correct' for d1,d2 in zip(decision1, decision2)]
     accuracy = combined_decision.count('Correct')/len(combined_decision)
     return accuracy, combined_decision


### PR DESCRIPTION
Description of the PR:
This PR adds the accuracy metric used in the MTGenEval paper. 
To evaluate accuracy, metric uses the system translations, the correct (gender-matched) references and incorrect (counterfactual/flipped) references. It first checks the references for unique/gender-specific terms, then check for overlap with the incorrect gender and the hypothesis. If there is overlap, the segment is marked as incorrect.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
